### PR TITLE
fix: release build boots in dev mode (webview connection refused) + ready event race

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,13 @@ edition = "2021"
 name = "dsh_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+
+[features]
+# 发布构建需显式声明 custom-protocol: tauri 的 build script 以 dev = !custom_protocol
+# 判定模式,缺省时 release 也会回退到 devUrl(http://localhost:1420),webview 显示
+# 连接被拒绝而不是应用界面(直接 cargo build --release 必现)。
+custom-protocol = ["tauri/custom-protocol"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/dsh.rs
+++ b/src-tauri/src/dsh.rs
@@ -264,6 +264,25 @@ enum Attempt {
     Failed(String),
 }
 
+
+/// Emit `ready` repeatedly for a short window instead of once. The boot page's
+/// listener registers only after the embedded webview finishes loading, which
+/// races the fast local readiness probe — a one-shot emit can be missed and
+/// leave the window stuck on the boot spinner.
+fn emit_ready(app: &AppHandle, attached: bool, method: Option<String>) {
+    let app2 = app.clone();
+    std::thread::spawn(move || {
+        for _ in 0..10 {
+            let mut payload = json!({ "status": "ready", "attached": attached });
+            if let Some(m) = &method {
+                payload["method"] = json!(m);
+            }
+            let _ = app2.emit("dsh-status", payload);
+            std::thread::sleep(Duration::from_millis(400));
+        }
+    });
+}
+
 /// Drive startup from a background thread. Emits `dsh-status` events:
 /// `{status:"starting",method}` per attempt, then either
 /// `{status:"ready",attached,method}` or `{status:"error",message}` with every
@@ -271,7 +290,7 @@ enum Attempt {
 pub fn startup(app: AppHandle) {
     // Attach path: DSH already up — never spawn, never kill on exit.
     if probe_ready_once() {
-        let _ = app.emit("dsh-status", json!({ "status": "ready", "attached": true }));
+        emit_ready(&app, true, None);
         crate::menu::install(app);
         return;
     }
@@ -319,10 +338,7 @@ fn try_candidate(app: &AppHandle, candidate: &Candidate) -> Attempt {
             // Hand the owned child to managed state; teardown kills its tree.
             let state = app.state::<DshState>();
             *state.inner.lock().unwrap() = Some(DshInner { child, pid });
-            let _ = app.emit(
-                "dsh-status",
-                json!({ "status": "ready", "attached": false, "method": candidate.label }),
-            );
+            emit_ready(app, false, Some(candidate.label.clone()));
             crate::menu::install(app.clone());
             return Attempt::Ready;
         }


### PR DESCRIPTION
# PR: 修复 release 构建以 dev 模式启动（webview 显示连接被拒）+ ready 事件竞态

## 提交 1 — Cargo.toml: 显式声明 `custom-protocol` feature

**问题**：直接 `cargo build --release` 构建本项目时，exe 正常产出，但窗口内 webview
永远停在 Chromium 错误页 "localhost 拒绝连接 / ERR_CONNECTION_REFUSED"，不显示应用 UI。

**根因**：tauri 的 build script（`tauri-2.x.x/build.rs`）以

```rust
let custom_protocol = has_feature("custom-protocol");
let dev = !custom_protocol;
alias("dev", dev);
```

判定构建模式。本项目 `Cargo.toml` 未声明该 feature，导致 **release 构建也被标记为
dev 模式**，`generate_context!` 因而使用 `tauri.conf.json` 的 `devUrl`
（`http://localhost:1420`）作为 webview 初始地址——1420 端口无服务，窗口显示连接被拒。
（`pnpm tauri build` 的 CLI 会自行启用 `tauri/custom-protocol`，所以走 CLI 构建不受影响；
但 README 中作为备选的手动 `cargo build --release` 路径必现此问题。）

**修复**：按官方 create-tauri-app 模板的标准姿势声明 feature：

```toml
[features]
custom-protocol = ["tauri/custom-protocol"]
```

**验证**：修复后 `cargo build --release --features custom-protocol` → 运行 exe →
webview 正常加载内嵌 UI 并跳转到 DSH webchat（PrintWindow 截图确认）。

## 提交 2 — dsh.rs: `ready` 事件重发，修复启动页卡死竞态

**问题**：Rust 侧 `startup()` 在后台线程探测就绪后**只发一次** `dsh-status: ready`；
boot 页面（内嵌 webview）的监听器要等页面加载完成后才注册，本地探测极快，
事件经常先于监听器到达而被丢弃——窗口会永远停在 "正在启动 DSH…" 加载页。

**修复**：新增 `emit_ready()`，就绪后在 4 秒内重发 10 次，无论监听器何时注册都能收到。

## 复现与验证

- 复现：`cargo build --release`（未启用 custom-protocol）→ 运行 exe → 连接被拒错误页
- 修复后：按上述方式构建运行 → 正常显示 DSH webchat

## 相关链接

- 同类问题：[Tauri GUI shows blank white screen in production builds](https://github.com/mmogr/gglib/issues/296)
- tauri CLI 相关改动：[refactor(cli): use `tauri/custom-protocol` instead of relying on user…](https://github.com/tauri-apps/tauri/commit/b9e6a01879d9233040f3d3fab11c59e70563da7e)
